### PR TITLE
Fix installation command using binaries

### DIFF
--- a/build_instructions/index.rst
+++ b/build_instructions/index.rst
@@ -9,7 +9,7 @@ Install
 PlanSys2 and its dependencies are released as binaries.
 You may install it via the following to get the latest stable released version:
 
-  ``sudo apt install ros-<distro>-plansys2_*``
+  ``sudo apt install ros-<distro>-plansys2-*``
 
 
 Build

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -19,7 +19,7 @@ Installation
 
    .. code-block:: bash
 
-      sudo apt install ros-<ros2-distro>-plansys2_*
+      sudo apt install ros-<ros2-distro>-plansys2-*
 
 Running the Example
 *******************


### PR DESCRIPTION
Currently the command to install Plansys2 using binaries is using an underscore: 
```
sudo apt install ros-<distro>-plansys2_*
```

It should use a hyphen to install all packages correctly:
```
sudo apt install ros-<distro>-plansys2-*
```
